### PR TITLE
Remove Sandbar from Useful Libraries

### DIFF
--- a/resources/public/md/useful_libraries.md
+++ b/resources/public/md/useful_libraries.md
@@ -23,7 +23,6 @@ to those already included with Luminus.
 * [buddy](https://github.com/niwibe/buddy) - a complete security library for clojure
 * [Friend](https://github.com/cemerick/friend) - an extensible authentication and authorization library
 * [clj-ldap](https://github.com/pauldorman/clj-ldap) - a library for talking to LDAP servers
-* [Sandbar](https://github.com/brentonashworth/sandbar) - a web application library with higher level abstractions for Compojure, Ring
 * [ring-basic-authentication](https://github.com/remvee/ring-basic-authentication) - Ring middleware to enforce basic authentication
 
 ## Caching


### PR DESCRIPTION
Since Brenton Ashworth's original GitHub project for sandbar is no longer available, I have removed the link on the Useful Libraries page. There are still a couple of forks out there, but from what I can tell, there is not a canonical fork. Also the wiki that contained the most useful documentation is no longer available.